### PR TITLE
cryptfs_hw: Support devices use metadata as key

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -21,8 +21,8 @@ cc_library_shared {
             device_support_legacy_hwfde: {
                 cflags: ["-DLEGACY_HW_DISK_ENCRYPTION"],
             },
-            device_support_wait_for_qsee: {
-                cflags: ["-DWAIT_FOR_QSEE"],
+            uses_metadata_as_fde_key: {
+                cflags: ["-DUSE_METADATA_FOR_KEY"],
             },
         },
     },

--- a/cryptfs_hw.c
+++ b/cryptfs_hw.c
@@ -81,6 +81,10 @@ static int (*qseecom_wipe_key)(int);
 
 #define CRYPTFS_HW_ALGO_MODE_AES_XTS 			0x3
 
+#ifndef USE_METADATA_FOR_KEY
+#define METADATA_PARTITION_NAME "/dev/block/bootdevice/by-name/metadata"
+#endif
+
 enum cryptfs_hw_key_management_usage_type {
 	CRYPTFS_HW_KM_USAGE_DISK_ENCRYPTION		= 0x01,
 	CRYPTFS_HW_KM_USAGE_FILE_ENCRYPTION		= 0x02,
@@ -457,6 +461,20 @@ int is_ice_enabled(void)
 {
   char prop_storage[PATH_MAX];
   int storage_type = 0;
+
+#ifndef USE_METADATA_FOR_KEY
+  /*
+   * Since HW FDE is a compile time flag (due to QSSI requirements),
+   * this API conflicts with Metadata encryption even when ICE is
+   * enabled, as it encrypts the whole disk instead. Adding this
+   * workaround to return 0 if metadata partition is present.
+   */
+
+  if (access(METADATA_PARTITION_NAME, F_OK) == 0) {
+    SLOGI("Metadata partition, returning false");
+    return 0;
+  }
+#endif
 
   if (property_get("ro.boot.bootdevice", prop_storage, "")) {
     if (strstr(prop_storage, "ufs")) {


### PR DESCRIPTION
* This fixes FDE devices which uses metadata partition as encryption key.
Errors:
> Logcat:
E Cryptfs_hw: Error::ioctl call to create encryption key for usage 1 failed with ret = -1, errno = 14
> Dmesg:
scm_call failed: func id 0x72000504, ret: -2, syscall returns: 0xfffffffffffffffc, 0x0, 0x0
QSEECOM: __qseecom_set_clear_ce_key: scm call to set QSEOS_PIPE_ENC key failed : -22
QSEECOM: qseecom_wipe_key: Failed to wipe key: pipe 2, ce 0: -14
QSEECOM: qseecom_ioctl: failed to wipe encryption key: -14

Test: Boot griffin with encrypted data
Signed-off-by: Erfan Abdi <erfangplus@gmail.com>
Change-Id: Id7a6474fe7fe46e0d4e4ebb3b24e1ba940971df4